### PR TITLE
Refactor print_receipt function for receipt PDF generation

### DIFF
--- a/django_pos/print_receipt.py
+++ b/django_pos/print_receipt.py
@@ -17,5 +17,3 @@ def print_receipt():
     HTML(string=html_template).write_pdf(
         target="receipt.pdf", stylesheets=[CSS(css_url)])
 
-
-print_receipt()


### PR DESCRIPTION
### Summary

This pull request refactors the `print_receipt` function in the receipt generation module. 
### Changes

- It is unnecessary to call `print_receipt` function directly. It should only be called when printing a receipt.

### Testing

The functionality remains the same. To verify:
1. Ensure the `sales/receipt_pdf.html` template is present and correctly formatted.
2. Run the `print_receipt` function and check the generated `receipt.pdf`.
3. Verify the receipt PDF is created with the correct styling and data.

### Notes

No new dependencies were introduced. This change is backward compatible and does not affect the current behavior of the application.
@betofleitass 